### PR TITLE
Change `CommandError` and `MessageInfo` to public

### DIFF
--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct CommandError: Error {
-  var commandStack: [ParsableCommand.Type]
+public struct CommandError: Error {
+  public var commandStack: [ParsableCommand.Type]
   var parserError: ParserError
 }
 

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -11,12 +11,12 @@
 
 @_implementationOnly import Foundation
 
-enum MessageInfo {
+public enum MessageInfo {
   case help(text: String)
   case validation(message: String, usage: String)
   case other(message: String, exitCode: Int32)
   
-  init(error: Error, type: ParsableArguments.Type) {
+  public init(error: Error, type: ParsableArguments.Type) {
     var commandStack: [ParsableCommand.Type]
     var parserError: ParserError? = nil
     
@@ -93,7 +93,7 @@ enum MessageInfo {
     }
   }
   
-  var message: String {
+  public var message: String {
     switch self {
     case .help(text: let text):
       return text
@@ -104,7 +104,7 @@ enum MessageInfo {
     }
   }
   
-  var fullText: String {
+  public var fullText: String {
     switch self {
     case .help(text: let text):
       return text
@@ -123,7 +123,7 @@ enum MessageInfo {
     }
   }
 
-  var exitCode: ExitCode {
+  public var exitCode: ExitCode {
     switch self {
     case .help: return ExitCode.success
     case .validation: return ExitCode.validationFailure


### PR DESCRIPTION
Change `CommandError` and `MessageInfo` to `public`. The motivation behind it was the desire to react to such an error with a beautiful message.